### PR TITLE
Set minimum window dimensions

### DIFF
--- a/src/main/java/com/insightfullogic/honest_profiler/delivery/javafx/WindowViewModel.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/delivery/javafx/WindowViewModel.java
@@ -28,6 +28,8 @@ public class WindowViewModel {
     public Parent display(Window window) {
         Parent parent = loader.load(window.getFxmlFile());
         stage.setScene(new Scene(parent));
+        stage.setMinWidth(650);
+        stage.setMinHeight(400);
         return parent;
     }
 


### PR DESCRIPTION
This makes the window not try to be 1px by 1px on tiling window managers like i3.

Sizes mirrored from the XML.  Setting minWidth/minHeight attributes in the XML seemingly does nothing.
