### PR TITLE
Resolve exceptions being thrown when updating components when not on a FX app thread

### DIFF
--- a/src/main/java/com/insightfullogic/honest_profiler/delivery/javafx/profile/TraceCountViewModel.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/delivery/javafx/profile/TraceCountViewModel.java
@@ -1,7 +1,8 @@
 package com.insightfullogic.honest_profiler.delivery.javafx.profile;
 
-import com.insightfullogic.honest_profiler.core.collector.Profile;
 import com.insightfullogic.honest_profiler.core.ProfileListener;
+import com.insightfullogic.honest_profiler.core.collector.Profile;
+import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 
@@ -12,7 +13,6 @@ public class TraceCountViewModel implements ProfileListener {
 
     @Override
     public void accept(Profile profile) {
-        traceCount.setText(profile.getTraceCount() + " samples");
+        Platform.runLater(() -> traceCount.setText(profile.getTraceCount() + " samples"));
     }
-
 }

--- a/src/main/java/com/insightfullogic/honest_profiler/delivery/javafx/profile/TreeViewCell.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/delivery/javafx/profile/TreeViewCell.java
@@ -1,6 +1,7 @@
 package com.insightfullogic.honest_profiler.delivery.javafx.profile;
 
 import com.insightfullogic.honest_profiler.core.collector.ProfileNode;
+import javafx.application.Platform;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.control.TreeCell;
@@ -45,14 +46,17 @@ public class TreeViewCell extends TreeCell<ProfileNode> {
         if (adapter == null)
             return;
 
-        switch (adapter.getType()) {
-            case THREAD:
-                setText("Thread " + adapter.getThreadId());
-                return;
-            case METHOD:
-                renderMethodNode(profileNode, empty);
-                return;
-        }
+        Platform.runLater(() -> {
+            switch (adapter.getType()) {
+                case THREAD:
+                    setText("Thread " + adapter.getThreadId());
+                    return;
+                case METHOD:
+                    renderMethodNode(profileNode, empty);
+                    return;
+            }
+        });
+
     }
 
     private void renderMethodNode(ProfileNode profileNode, boolean empty) {

--- a/src/main/java/com/insightfullogic/honest_profiler/delivery/javafx/profile/TreeViewModel.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/delivery/javafx/profile/TreeViewModel.java
@@ -1,9 +1,10 @@
 package com.insightfullogic.honest_profiler.delivery.javafx.profile;
 
-import com.insightfullogic.honest_profiler.core.collector.Profile;
 import com.insightfullogic.honest_profiler.core.ProfileListener;
+import com.insightfullogic.honest_profiler.core.collector.Profile;
 import com.insightfullogic.honest_profiler.core.collector.ProfileNode;
 import com.insightfullogic.honest_profiler.core.collector.ProfileTree;
+import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.control.TreeView;
 
@@ -23,7 +24,7 @@ public class TreeViewModel implements ProfileListener {
     @Override
     public void accept(Profile profile) {
         List<ProfileTree> trees = profile.getTrees();
-        treeView.setRoot(new TreeNodeAdapter(trees));
+        Platform.runLater(() -> treeView.setRoot(new TreeNodeAdapter(trees)));
     }
 
 }


### PR DESCRIPTION
I recieved frequent exceptions of the form:

```
java.lang.IllegalStateException: Not on FX application thread; currentThread = ProfileUpdateModerator
    at com.sun.javafx.tk.Toolkit.checkFxUserThread(Toolkit.java:210) ~[jfxrt.jar:na]
    at com.sun.javafx.tk.quantum.QuantumToolkit.checkFxUserThread(QuantumToolkit.java:393) ~[jfxrt.jar:na]
    at javafx.scene.Parent$2.onProposedChange(Parent.java:372) ~[jfxrt.jar:na]
    at com.sun.javafx.collections.VetoableListDecorator.setAll(VetoableListDecorator.java:115) ~[jfxrt.jar:na]
    at com.sun.javafx.collections.VetoableListDecorator.setAll(VetoableListDecorator.java:110) ~[jfxrt.jar:na]
    at com.sun.javafx.scene.control.skin.LabeledSkinBase.updateChildren(LabeledSkinBase.java:635) ~[jfxrt.jar:na]
    at com.sun.javafx.scene.control.skin.LabeledSkinBase.handleControlPropertyChanged(LabeledSkinBase.java:207) ~[jfxrt.jar:na]
    at com.sun.javafx.scene.control.skin.LabelSkin.handleControlPropertyChanged(LabelSkin.java:52) ~[jfxrt.jar:na]
    at com.sun.javafx.scene.control.skin.BehaviorSkinBase$2.call(BehaviorSkinBase.java:189) ~[jfxrt.jar:na]
    at com.sun.javafx.scene.control.skin.BehaviorSkinBase$2.call(BehaviorSkinBase.java:187) ~[jfxrt.jar:na]
    at com.sun.javafx.scene.control.MultiplePropertyChangeListenerHandler$1.changed(MultiplePropertyChangeListenerHandler.java:55) ~[jfxrt.jar:na]
    at javafx.beans.value.WeakChangeListener.changed(WeakChangeListener.java:89) ~[jfxrt.jar:na]
    at com.sun.javafx.binding.ExpressionHelper$SingleChange.fireValueChangedEvent(ExpressionHelper.java:176) ~[jfxrt.jar:na]
    at com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:80) ~[jfxrt.jar:na]
    at javafx.beans.property.StringPropertyBase.fireValueChangedEvent(StringPropertyBase.java:103) ~[jfxrt.jar:na]
    at javafx.beans.property.StringPropertyBase.markInvalid(StringPropertyBase.java:110) ~[jfxrt.jar:na]
    at javafx.beans.property.StringPropertyBase.set(StringPropertyBase.java:143) ~[jfxrt.jar:na]
    at javafx.beans.property.StringPropertyBase.set(StringPropertyBase.java:49) ~[jfxrt.jar:na]
    at javafx.beans.property.StringProperty.setValue(StringProperty.java:65) ~[jfxrt.jar:na]
    at javafx.scene.control.Labeled.setText(Labeled.java:151) ~[jfxrt.jar:na]
    at com.insightfullogic.honest_profiler.delivery.javafx.profile.TraceCountViewModel.accept(TraceCountViewModel.java:16) ~[classes/:na]
    at com.insightfullogic.honest_profiler.delivery.javafx.profile.CachingProfileListener.accept(CachingProfileListener.java:32) ~[classes/:na]
    at com.insightfullogic.honest_profiler.core.ProfileUpdateModerator.run(ProfileUpdateModerator.java:29) ~[classes/:na]
```

From these componets updating.

This also seems to resolve #48
