### PR TITLE
Fix the thread on the tree view being given a graphic

### DIFF
--- a/src/main/java/com/insightfullogic/honest_profiler/delivery/javafx/profile/TreeViewCell.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/delivery/javafx/profile/TreeViewCell.java
@@ -50,6 +50,7 @@ public class TreeViewCell extends TreeCell<ProfileNode> {
             switch (adapter.getType()) {
                 case THREAD:
                     setText("Thread " + adapter.getThreadId());
+                    setGraphic(null);
                     return;
                 case METHOD:
                     renderMethodNode(profileNode, empty);


### PR DESCRIPTION
Sometimes the top level thread cell in the tree view is given a bar icon. This seems to be a bug as there is no reason for it to have one.
