### PR TITLE
get address of jvm functions on both osx and linux

### DIFF
--- a/src/main/cpp/globals.h
+++ b/src/main/cpp/globals.h
@@ -140,14 +140,8 @@ public:
 
   template <class FunctionType>
   static inline FunctionType GetJvmFunction(const char *function_name) {
-    // get handle to library
-    static void *handle = dlopen("libjvm.so", RTLD_LAZY);
-    if (handle == NULL) {
-      return NULL;
-    }
-
     // get address of function, return null if not found
-    return bit_cast<FunctionType>(dlsym(handle, function_name));
+    return bit_cast<FunctionType>(dlsym(RTLD_DEFAULT, function_name));
   }
 
 private:


### PR DESCRIPTION
On osx libjvm.so is called libjvm.dylib, not libjvm.so. To fix loading of jvm functions on both linux and osx, I skip the reference to libjvm and use dlsym(RTLD_DEFAULT). This is a fix for the issue #52 I reported.

linux manpage dlsym(3):

"There are two special pseudo-handles, RTLD_DEFAULT and RTLD_NEXT. The former will find the first occurrence of the desired symbol using the default library search order. "

osx manpage dlsym(3):

"If dlsym() is called with the special handle RTLD_DEFAULT, then all mach-o images in the process (except those loaded with dlopen(xxx, RTLD_LOCAL)) are searched in the order they were loaded.  This can be a costly search and should be avoided."

Tested on OSX 10.9 and Ubuntu 12.04 both with java 8u11
