### PR TITLE
enhance scripts to work on Debian-like machines

### DIFF
--- a/src/main/scripts/console
+++ b/src/main/scripts/console
@@ -2,8 +2,8 @@
 
 set -eu
 
-java_path=`which java`
-java_home=`echo $java_path | sed 's/....$//'`
+java_path=$(readlink -f $(which javac))
+java_home=$(echo $java_path | sed 's/javac$//')
 tools_path="$java_home/../lib/tools.jar"
 
 java -cp $tools_path:honest-profiler.jar com.insightfullogic.honest_profiler.delivery.console.ConsoleEntry $@

--- a/src/main/scripts/gui
+++ b/src/main/scripts/gui
@@ -2,8 +2,8 @@
 
 set -eu
 
-java_path=`which java`
-java_home=`echo $java_path | sed 's/....$//'`
+java_path=$(readlink -f $(which javac))
+java_home=`echo $java_path | sed 's/javac$//'`
 tools_path="$java_home/../lib/tools.jar"
 
 java -cp $tools_path:honest-profiler.jar com.insightfullogic.honest_profiler.delivery.javafx.JavaFXEntry


### PR DESCRIPTION
On Debian-like machines, `$(which java)` is always `/usr/bin/java.`.

`readlink -f` unpicks this through the alternatives system into e.g. `/usr/lib/jvm/java-8-oracle/jre/bin/java`.

And, have to use `javac`, not `java`, to remove the `/jre/` from the path.
