### PR TITLE
Fixing default log file name selection

### DIFF
--- a/src/main/cpp/profiler.h
+++ b/src/main/cpp/profiler.h
@@ -3,6 +3,7 @@
 #include <unistd.h>
 #include <chrono>
 #include <sstream>
+#include <string>
 
 #include "globals.h"
 #include "stacktraces.h"
@@ -15,6 +16,7 @@
 using namespace std::chrono;
 using std::ofstream;
 using std::ostringstream;
+using std::string;
 
 class SignalHandler {
 public:
@@ -39,10 +41,12 @@ public:
         long epochMillis = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 
         char* fileName = configuration->logFilePath;
+        string fileNameStr;
         if (fileName == NULL) {
             ostringstream fileBuilder;
             fileBuilder << "log-" << pid << "-" << epochMillis << ".hpl";
-            fileName = (char *) fileBuilder.str().c_str();
+            fileNameStr = fileBuilder.str();
+            fileName = (char *) fileNameStr.c_str();
         }
 
         logFile = new ofstream(fileName, ofstream::out | ofstream::binary);


### PR DESCRIPTION
Presently, when selecting a default log file name, `filename` ends up as a dangling pointer, since the temporary `fileBuilder.str()` will be destroyed at the end of the expression - see [Notes](http://en.cppreference.com/w/cpp/io/basic_ostringstream/str#Notes). This actually causes issues on OS X, where a log file doesn't get created unless the name is explicitly specified. This patch is one way to fix the issue without having to do any explicit memory management - there might be better ones.
