### PR TITLE
Fixing test cases on OS X, since pubsetbuf doesn't work

### DIFF
--- a/src/test/cpp/ostreambuf.h
+++ b/src/test/cpp/ostreambuf.h
@@ -1,0 +1,17 @@
+#ifndef OSTREAMBUF_H
+#define OSTREAMBUF_H
+
+// based on http://stackoverflow.com/a/1495582/382079
+#include <streambuf>
+
+template <class char_type>
+struct ostreambuf : public std::basic_streambuf<char_type, std::char_traits<char_type> >
+{
+  ostreambuf(char_type *buffer, std::streamsize bufferLength)
+  {
+    // set the "put" pointer the start of the buffer and record its length.
+    this->setp(buffer, buffer + bufferLength);
+  }
+};
+
+#endif /* OSTREAMBUF_H */

--- a/src/test/cpp/test_log_writer.cpp
+++ b/src/test/cpp/test_log_writer.cpp
@@ -4,10 +4,11 @@
 #include <limits>
 
 #include "fixtures.h"
+#include "ostreambuf.h"
 #include "../../main/cpp/circular_queue.h"
 #include "../../main/cpp/log_writer.h"
 
-using std::ostringstream;
+using std::ostream;
 using std::ofstream;
 
 #define copyString(from, to)                                                   \
@@ -23,10 +24,9 @@ bool stubFrameInformation(const JVMPI_CallFrame &frame, jvmtiEnv *jvmti,
 
 // Queue is too large to be stack allocated
 #define givenLogWriter()                                                       \
-  ostringstream output;                                                        \
-  char buffer[100];                                                            \
-  memset(buffer, 0, sizeof(buffer));                                           \
-  output.rdbuf()->pubsetbuf(buffer, sizeof(buffer));                           \
+  char buffer[100] = {};                                                       \
+  ostreambuf<char> outputBuffer(buffer, sizeof(buffer));                       \
+  ostream output(&outputBuffer);                                               \
   LogWriter logWriter(output, &stubFrameInformation, NULL);                    \
   CircularQueue *queue = new CircularQueue(logWriter);
 


### PR DESCRIPTION
`pubsetbuf` isn't guaranteed to change the underlying buffer, and it in fact doesn't on OS X 10.10 (compiling with clang-600.0.54), which causes test failures. Initializing an `ostream` with a custom stream buffer should be cross-platform, however.
