### PR TITLE
Fix for issue #193 

### DIFF
--- a/src/test/cpp/test.h
+++ b/src/test/cpp/test.h
@@ -7,7 +7,7 @@
 #   include <UnitTest++.h>
 #endif
 
-#if __GNUC__ == 4 && __GNUC_MINOR__ < 6 && !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__clang__)
+#if __GNUC__ == 4 && __GNUC_MINOR__ < 6
 #	define DISABLE_CPP11
 #endif
 

--- a/src/test/cpp/test.h
+++ b/src/test/cpp/test.h
@@ -2,9 +2,13 @@
 #define HONEST_PROFILER_TEST_H
 
 #ifdef __APPLE__
-#include <UnitTest++/UnitTest++.h>
+#   include <UnitTest++/UnitTest++.h>
 #else
-#include <UnitTest++.h>
-#endif 
+#   include <UnitTest++.h>
+#endif
 
-#endif //HONEST_PROFILER_TEST_H
+#if __GNUC__ == 4 && __GNUC_MINOR__ < 6 && !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__clang__)
+#	define DISABLE_CPP11
+#endif
+
+#endif

--- a/src/test/cpp/test_maps.cpp
+++ b/src/test/cpp/test_maps.cpp
@@ -1,4 +1,7 @@
 #include "test.h"
+
+#ifndef DISABLE_CPP11
+
 #include "../../main/cpp/thread_map.h"
 
 #include <sstream>
@@ -364,3 +367,5 @@ TEST(LockFreeHashMapConcurrentMixedLoad) {
 		CONCURRENT_EPILOGUE();
 	}
 }
+
+#endif

--- a/src/test/cpp/test_misc.cpp
+++ b/src/test/cpp/test_misc.cpp
@@ -1,4 +1,7 @@
 #include "test.h"
+
+#ifndef DISABLE_CPP11
+
 #include "../../main/cpp/globals.h"
 #include <thread>
 #include <chrono>
@@ -58,3 +61,5 @@ TEST(ClockConcurrent) {
 		CHECK(begin <= t && t <= end);
 	}
 }
+
+#endif

--- a/src/test/cpp/test_profiler_config.cpp
+++ b/src/test/cpp/test_profiler_config.cpp
@@ -1,7 +1,10 @@
+#include "test.h"
+
+#ifndef DISABLE_CPP11
+
 #include <thread>
 #include <vector>
 #include <iostream>
-#include "test.h"
 #include "../../main/cpp/profiler.h"
 
 #ifndef __APPLE__
@@ -222,3 +225,5 @@ TEST_FIXTURE(ProfilerControl, ProfilerConcurrentModification) {
 }
 
 #endif
+
+#endif // DISABLE_CPP11


### PR DESCRIPTION
Hi,

This PR fixes issue #193 and makes `libagent.so` gcc-4.4 compatible again. I broke compatibility previously when I was developing concurrent map, since non-primitive types appeared in template arguments of `std::atomic` and it doesn't work with `cstdatomic` in g++ 4.4.

Also `nullptr` will be replaced with `NULL` in old gcc's, which is sufficient for honest-profiler (not 100% correct though).

Master passes both java & native tests for both 4.4 and 4.8 under Linux.