### PR TITLE
Fix : Diff column labels missing

### DIFF
--- a/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/controller/AbstractProfileDiffViewController.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/controller/AbstractProfileDiffViewController.java
@@ -42,7 +42,7 @@ import javafx.scene.text.Text;
  * The superclass also provides some common UI helper methods for column configuration.
  * <p>
  * @see AbstractDiff class javadoc for an explanation of the "Base" and "New" terminology
- * <p>
+ *      <p>
  * @param <T> the data type of the targets
  * @param <U> the type of the items contained in the View
  */
@@ -131,6 +131,10 @@ public abstract class AbstractProfileDiffViewController<T, U> extends AbstractVi
     {
         this.baseContext = baseContext;
         this.newContext = newContext;
+
+        // Called here because for the Diff column headers, the profile contexts are needed to display the profile
+        // number label.
+        initializeTable();
     }
 
     // Source-Target Binding

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/controller/AbstractProfileViewController.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/controller/AbstractProfileViewController.java
@@ -80,6 +80,8 @@ public abstract class AbstractProfileViewController<T, U> extends AbstractViewCo
     public void setProfileContext(ProfileContext profileContext)
     {
         this.profileContext = profileContext;
+
+        initializeTable();
     }
 
     /**

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/controller/AbstractViewController.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/controller/AbstractViewController.java
@@ -158,9 +158,6 @@ public abstract class AbstractViewController<T> extends AbstractController
             return;
         }
 
-        // Called here because I18N is needed, so there's a dependency on the availability of the ApplicationContext.
-        initializeTable();
-
         initializeFilters(applicationContext);
     }
 
@@ -219,11 +216,13 @@ public abstract class AbstractViewController<T> extends AbstractController
     protected abstract void refresh();
 
     /**
-     * Initialize the {@link TableView} or {@link TreeTableView} which contains the View data.
+     * Initialize the {@link TableView} or {@link TreeTableView} which contains the View data, if applicable.
      * <p>
-     * This method is provided because, due to I18N, the {@link ApplicationContext} is needed for proper initialization,
-     * since the column headers are internationalized. This method is therefore called in this class in the
-     * {@link #setApplicationContext(ApplicationContext)} method.
+     * Care should be taken in the subclassed to call this at the right time, because some contextual information may be
+     * needed. The {@link ApplicationContext} must be set for the I18N to work, and in the case of Diff column headers,
+     * the {@link ProfileContext}s for the profiles being compared should also be known. In the current implementation
+     * therefore, the method is called in the {@link AbstractProfileViewController#setProfileContext(ProfileContext)}
+     * and {@link AbstractProfileDiffViewController#setProfileContexts(ProfileContext, ProfileContext)} methods.
      */
     protected abstract void initializeTable();
 

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/controller/TreeViewController.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/javafx/controller/TreeViewController.java
@@ -118,8 +118,6 @@ public class TreeViewController extends AbstractProfileViewController<Tree, Node
         super.initialize(ENTRY);
         super.initialize(filterController, filterButton, quickFilterButton, quickFilterText);
         super.initialize(threadGroupingLabel, threadGrouping, frameGroupingLabel, frameGrouping);
-
-        initializeTable();
     }
 
     // Instance Accessors


### PR DESCRIPTION
Fixes a regression, in which certain column headers in diff views no longer show the profile labels.

Replaces part of deleted PR #192 .