### PR TITLE
Fix : Comparison "EQUALS_NR" value comparison

### DIFF
--- a/src/main/java/com/insightfullogic/honest_profiler/core/aggregation/filter/Comparison.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/core/aggregation/filter/Comparison.java
@@ -64,7 +64,7 @@ public enum Comparison
         switch (comparison)
         {
             case EQUALS_NR:
-                return nr -> nr == value;
+                return nr -> nr.doubleValue() == value.doubleValue();
             case GT:
                 return nr -> nr > value;
             case LT:
@@ -92,7 +92,7 @@ public enum Comparison
         switch (comparison)
         {
             case EQUALS_NR:
-                return nr -> nr == value;
+                return nr -> nr.intValue() == value.intValue();
             case GT:
                 return nr -> nr > value;
             case LT:
@@ -120,7 +120,7 @@ public enum Comparison
         switch (comparison)
         {
             case EQUALS_NR:
-                return nr -> nr == value;
+                return nr -> nr.longValue() == value.longValue();
             case GT:
                 return nr -> nr > value;
             case LT:


### PR DESCRIPTION
The EQUALS_NR Comparison can fail because it checks on Number identity rather than the value.

Trivial, small fix.

As in other current PRs by me - only the last commit in the PR commit list is significant, the other ones amount to no changes.