### PR TITLE
#185: Add method signatures to agent output

### DIFF
--- a/src/main/cpp/concurrent_map.h
+++ b/src/main/cpp/concurrent_map.h
@@ -420,11 +420,10 @@ struct Migration : public JobCoordinator::Job {
 
 		Source() : table(nullptr), index(0) {
 		}
-
-#ifdef C_ATOMICS
+		
+		// Workaround for cstdatomic
 		Source(const Source& src) : table(src.table), index(src.index.load(std::memory_order_relaxed)) {
 		}
-#endif
 
 		void destroy() {
 			delete table;

--- a/src/main/cpp/concurrent_map.h
+++ b/src/main/cpp/concurrent_map.h
@@ -421,6 +421,11 @@ struct Migration : public JobCoordinator::Job {
 		Source() : table(nullptr), index(0) {
 		}
 
+#ifdef C_ATOMICS
+		Source(const Source& src) : table(src.table), index(src.index.load(std::memory_order_relaxed)) {
+		}
+#endif
+
 		void destroy() {
 			delete table;
 		}

--- a/src/main/cpp/log_writer.cpp
+++ b/src/main/cpp/log_writer.cpp
@@ -193,3 +193,17 @@ void LogWriter::recordNewMethod(const map::HashType methodId, const char *fileNa
     writeWithSize(methodName);
     output_.flush();
 }
+
+void LogWriter::recordNewMethod(const map::HashType methodId, const char *fileName, 
+    const char *className, const char *genericClassName, 
+    const char *methodName, const char *methodSignature, const char *genericMethodSignature) {
+    output_.put(NEW_METHOD_SIGNATURE);
+    writeValue(methodId);
+    writeWithSize(fileName);
+    writeWithSize(className);
+    writeWithSize(genericClassName ? genericClassName : "");
+    writeWithSize(methodName);
+    writeWithSize(methodSignature);
+    writeWithSize(genericMethodSignature ? genericMethodSignature : "");
+    output_.flush();
+}

--- a/src/main/cpp/log_writer.h
+++ b/src/main/cpp/log_writer.h
@@ -22,6 +22,10 @@ public:
             const char *class_name,
             const char *method_name) = 0;
 
+    virtual void recordNewMethod(const map::HashType methodId, const char *fileName, 
+            const char *className, const char *genericClassName, 
+            const char *methodName, const char *methodSignature, const char *genericMethodSignature) = 0;
+
     virtual ~MethodListener() {
     }
 };
@@ -34,7 +38,8 @@ const byte TRACE_START = 1; // maintain backward compatibility
 const byte TRACE_WITH_TIME = 11; 
 const byte FRAME_BCI_ONLY = 2; // maintain backward compatibility
 const byte FRAME_FULL = 21;
-const byte NEW_METHOD = 3;
+const byte NEW_METHOD = 3; // maintain backward compatibility
+const byte NEW_METHOD_SIGNATURE = 31;
 const byte THREAD_META = 4;
 // Error values for line number. If BCI is an error value we report the BCI error value.
 const jint ERR_NO_LINE_INFO = -100;
@@ -67,6 +72,10 @@ public:
 
     virtual void recordNewMethod(method_id methodId, const char *file_name,
             const char *class_name, const char *method_name);
+
+    virtual void recordNewMethod(const map::HashType methodId, const char *fileName, 
+            const char *className, const char *genericClassName, 
+            const char *methodName, const char *methodSignature, const char *genericMethodSignature);
 
 private:
     ostream &output_;

--- a/src/main/java/com/insightfullogic/honest_profiler/core/collector/Frame.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/core/collector/Frame.java
@@ -36,6 +36,10 @@ public interface Frame
 
     String getMethodName();
 
+    String getMethodSignature();
+
+    String getMethodReturnType();
+
     int getBci();
 
     int getLine();

--- a/src/main/java/com/insightfullogic/honest_profiler/core/collector/FullFrame.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/core/collector/FullFrame.java
@@ -65,6 +65,18 @@ public class FullFrame implements Frame
     }
 
     @Override
+    public String getMethodSignature()
+    {
+        return method.getMethodSignature();
+    }
+    
+    @Override
+    public String getMethodReturnType()
+    {
+        return method.getMethodReturnType();
+    }
+
+    @Override
     public int getBci()
     {
         return frame.getBci();

--- a/src/main/java/com/insightfullogic/honest_profiler/core/parser/LogParser.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/core/parser/LogParser.java
@@ -62,6 +62,7 @@ public class LogParser
     private static final int STACK_FRAME_BCI_ONLY = 2;
     private static final int STACK_FRAME_FULL = 21;
     private static final int NEW_METHOD = 3;
+    private static final int NEW_METHOD_SIGNATURE = 31;
     private static final int THREAD_META = 4;
 
     private final LogEventListener listener;
@@ -117,6 +118,9 @@ public class LogParser
                 case NEW_METHOD:
                     readNewMethod(input);
                     return COMPLETE_RECORD;
+                case NEW_METHOD_SIGNATURE:
+                    readNewMethodSignature(input);
+                    return COMPLETE_RECORD;
                 case THREAD_META:
                     readNewThreadMeta(input);
                     return COMPLETE_RECORD;
@@ -142,6 +146,13 @@ public class LogParser
     private void readNewMethod(ByteBuffer input)
     {
         Method newMethod = new Method(input.getLong(), readString(input), readString(input), readString(input));
+        newMethod.accept(listener);
+    }
+
+    private void readNewMethodSignature(ByteBuffer input)
+    {
+        Method newMethod = new Method(input.getLong(), readString(input), readString(input), readString(input), 
+            readString(input), readString(input), readString(input));
         newMethod.accept(listener);
     }
 

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/console/ConsoleLogDumpApplication.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/console/ConsoleLogDumpApplication.java
@@ -118,8 +118,10 @@ public class ConsoleLogDumpApplication
             @Override
             public void handle(Method method)
             {
-                BoundMethod boundMethod = new BoundMethod(method.getClassName(), method.getMethodName());
-                out.printf("Method    : %d -> %s.%s\n", method.getMethodId(), method.getClassName(), method.getMethodName());
+                BoundMethod boundMethod = new BoundMethod(method.getClassName(), 
+                    method.getMethodReturnType(), method.getMethodName(), method.getMethodSignature());
+                out.printf("Method    : %d -> %s %s.%s%s\n", method.getMethodId(), method.getMethodReturnType(),
+                    method.getClassName(), method.getMethodName(), method.getMethodSignature());
                 methodNames.put(method.getMethodId(), boundMethod);
             }
 
@@ -146,7 +148,7 @@ public class ConsoleLogDumpApplication
                     // bad sample dressed up as a frame
                     out.print("StackFrame: ");
                     indent(out);
-                    out.printf("%s::%s \n", boundMethod.className, boundMethod.methodName);
+                    out.printf("%s %s::%s%s \n", boundMethod.returnType, boundMethod.className, boundMethod.methodName, boundMethod.methodSignature);
                     Counter counter = errHistogram.computeIfAbsent(boundMethod.methodName, k -> new Counter());
                     counter.inc();
                 }
@@ -160,7 +162,8 @@ public class ConsoleLogDumpApplication
                 {
                     out.print("StackFrame: ");
                     indent(out);
-                    out.printf("%s::%s @ %s (bci=%s)\n", boundMethod.className, boundMethod.methodName, stackFrame.getLineNumber(), stackFrame.getBci());
+                    out.printf("%s %s::%s%s @ %s (bci=%s)\n", boundMethod.returnType, boundMethod.className, boundMethod.methodName, 
+                        boundMethod.methodSignature, stackFrame.getLineNumber(), stackFrame.getBci());
                 }
             }
 
@@ -212,13 +215,17 @@ public class ConsoleLogDumpApplication
 
     private static class BoundMethod
     {
+        private final String returnType;
         private final String className;
         private final String methodName;
+        private final String methodSignature;
 
-        public BoundMethod(String className, String methodName)
+        public BoundMethod(String className, String returnType, String methodName, String methodSignature)
         {
             this.className = className;
+            this.returnType = returnType;
             this.methodName = methodName;
+            this.methodSignature = methodSignature;
         }
     }
 

--- a/src/main/java/com/insightfullogic/honest_profiler/ports/console/ProfileFormat.java
+++ b/src/main/java/com/insightfullogic/honest_profiler/ports/console/ProfileFormat.java
@@ -106,15 +106,15 @@ public enum ProfileFormat
         }
         else if (frameInfo.getBci() == Frame.BCI_ERR_IGNORE)
         {
-            out.accept(String.format("(t %4.1f,s %4.1f) %s::%s",
+            out.accept(String.format("(t %4.1f,s %4.1f) %s::%s%s",
                 totalShare * 100, selfShare * 100,
-                frameInfo.getClassName(), frameInfo.getMethodName()));
+                frameInfo.getClassName(), frameInfo.getMethodName(), frameInfo.getMethodSignature()));
         }
         else
         {
-            out.accept(String.format("(t %4.1f,s %4.1f) %s::%s @ (bci=%d,line=%d)",
+            out.accept(String.format("(t %4.1f,s %4.1f) %s::%s%s @ (bci=%d,line=%d)",
                 totalShare * 100, selfShare * 100,
-                frameInfo.getClassName(), frameInfo.getMethodName(),
+                frameInfo.getClassName(), frameInfo.getMethodName(), frameInfo.getMethodSignature(),
                 frameInfo.getBci(), frameInfo.getLine()));
         }
     }


### PR DESCRIPTION
This PR adds class signature, method descriptor and method signature to the log. There are not so many changes in agent code since all method calls are already there. I updated Java parser, so it will be able to understand new log entries. Method params and return type (non-generic) will be shown in console applications. `com.insightfullogic.honest_profiler.core.parser.Method` will store class and method signatures but ignore them for now, since pretty printing is a bit more tricky for signatures.

There's a tiny concurrent map change as well (add a copy constructor to map::Migration::Source), that allows agent to be compiled by gcc-4.4.