### PR TITLE
agent: Protect ThreadBucket* returned from ThreadMap

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,96 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -38,7 +38,7 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit:     80
+ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,8 @@ set(TEST_FILES
     ${SRC_TEST}/test_agent.cpp
     ${SRC_TEST}/test.h
     ${SRC_TEST}/test_profiler_config.cpp
-    ${SRC_TEST}/test_maps.cpp)
+    ${SRC_TEST}/test_maps.cpp
+    ${SRC_TEST}/test_thread_map.cpp)
 
 
 ##########################################################

--- a/src/main/cpp/agent.cpp
+++ b/src/main/cpp/agent.cpp
@@ -70,11 +70,9 @@ void JNICALL OnVMInit(jvmtiEnv *jvmti, JNIEnv *jniEnv, jthread thread) {
         CreateJMethodIDsForClass(jvmti, klass);
     }
 
-#ifndef GETENV_NEW_THREAD_ASYNC_UNSAFE
     if (!configuration.host.empty() && !configuration.port.empty()) {
         controller->start();
     }
-#endif
 }
 
 void JNICALL OnClassPrepare(jvmtiEnv *jvmti_env, JNIEnv *jni_env,

--- a/src/main/cpp/circular_queue.h
+++ b/src/main/cpp/circular_queue.h
@@ -22,10 +22,9 @@ const size_t Capacity = Size + 1;
 
 class QueueListener {
 public:
-    virtual void record(const timespec &ts, const JVMPI_CallTrace &item, ThreadBucket *info = nullptr) = 0;
+    virtual void record(const timespec &ts, const JVMPI_CallTrace &item, ThreadBucketPtr info = ThreadBucketPtr(nullptr)) = 0;
 
-    virtual ~QueueListener() {
-    }
+    virtual ~QueueListener() {}
 };
 
 const int COMMITTED = 1;
@@ -35,7 +34,10 @@ struct TraceHolder {
     timespec tspec;
     std::atomic<int> is_committed;
     JVMPI_CallTrace trace;
-    ThreadBucket *info;
+    ThreadBucketPtr info;
+
+    TraceHolder() : info(nullptr) {
+    }
 };
 
 class CircularQueue {
@@ -52,9 +54,9 @@ public:
             delete[] frame_buffer_[i];
     }
 
-    bool push(const timespec &ts, const JVMPI_CallTrace &item, ThreadBucket *info = nullptr);
+    bool push(const timespec &ts, const JVMPI_CallTrace &item, ThreadBucketPtr info = ThreadBucketPtr(nullptr));
 
-    bool push(const JVMPI_CallTrace &item, ThreadBucket *info = nullptr);
+    bool push(const JVMPI_CallTrace &item, ThreadBucketPtr info = ThreadBucketPtr(nullptr));
 
     bool pop();
 

--- a/src/main/cpp/controller.h
+++ b/src/main/cpp/controller.h
@@ -33,9 +33,10 @@ public:
     bool isRunning() const;
 
 private:
-    JavaVM *jvm_;
-    jvmtiEnv *jvmti_;
-    Profiler *profiler_;
+    JavaVM *const jvm_;
+    jvmtiEnv *const jvmti_;
+    Profiler *const profiler_;
+    
     const ConfigurationOptions &configuration_;
     std::atomic_bool isRunning_;
 

--- a/src/main/cpp/log_writer.cpp
+++ b/src/main/cpp/log_writer.cpp
@@ -102,7 +102,7 @@ void LogWriter::record(const JVMPI_CallTrace &trace, ThreadBucketPtr info) {
 }
 
 void LogWriter::record(const timespec &ts, const JVMPI_CallTrace &trace, ThreadBucketPtr info) {
-    recordTraceStart(trace.num_frames, (map::HashType)trace.env_id, ts, std::move(info));
+    recordTraceStart(trace.num_frames, (map::HashType)trace.env_id, ts, info);
 
     for (int i = 0; i < trace.num_frames; i++) {
         JVMPI_CallFrame frame = trace.frames[i];
@@ -135,7 +135,7 @@ void LogWriter::inspectMethod(const method_id methodId, const JVMPI_CallFrame &f
     }
 }
 
-void LogWriter::inspectThread(map::HashType &threadId, ThreadBucketPtr info) {
+void LogWriter::inspectThread(map::HashType &threadId, ThreadBucketPtr& info) {
     std::string threadName;
 
     if (info.defined()) {
@@ -155,10 +155,10 @@ void LogWriter::inspectThread(map::HashType &threadId, ThreadBucketPtr info) {
     output_.flush();
 }
 
-void LogWriter::recordTraceStart(const jint numFrames, map::HashType envHash, ThreadBucketPtr info) {
+void LogWriter::recordTraceStart(const jint numFrames, map::HashType envHash, ThreadBucketPtr& info) {
     map::HashType threadId = -envHash;
 
-    inspectThread(threadId, std::move(info));
+    inspectThread(threadId, info);
 
     output_.put(TRACE_START);
     writeValue(numFrames);
@@ -166,10 +166,10 @@ void LogWriter::recordTraceStart(const jint numFrames, map::HashType envHash, Th
     output_.flush();
 }
 
-void LogWriter::recordTraceStart(const jint numFrames, map::HashType envHash, const timespec &ts, ThreadBucketPtr info) {
+void LogWriter::recordTraceStart(const jint numFrames, map::HashType envHash, const timespec &ts, ThreadBucketPtr& info) {
     map::HashType threadId = -envHash; // mark unrecognized threads with negative id's
     
-    inspectThread(threadId, std::move(info));
+    inspectThread(threadId, info);
 
     output_.put(TRACE_WITH_TIME);
     writeValue(numFrames);

--- a/src/main/cpp/log_writer.h
+++ b/src/main/cpp/log_writer.h
@@ -59,9 +59,9 @@ public:
 
     void record(const JVMPI_CallTrace &trace, ThreadBucketPtr info = ThreadBucketPtr(nullptr));
 
-    void recordTraceStart(const jint numFrames, map::HashType envHash, ThreadBucketPtr info);
+    void recordTraceStart(const jint numFrames, map::HashType envHash, ThreadBucketPtr& info);
 
-    void recordTraceStart(const jint numFrames, map::HashType envHash, const timespec &ts, ThreadBucketPtr info);
+    void recordTraceStart(const jint numFrames, map::HashType envHash, const timespec &ts, ThreadBucketPtr& info);
 
     // method are unique pointers, use a long to standardise
     // between 32 and 64 bits
@@ -96,7 +96,7 @@ private:
 
     void inspectMethod(const method_id methodId, const JVMPI_CallFrame &frame);
 
-    void inspectThread(map::HashType &threadId, ThreadBucketPtr info);
+    void inspectThread(map::HashType &threadId, ThreadBucketPtr& info);
 
     jint getLineNo(jint bci, jmethodID methodId);
 

--- a/src/main/cpp/log_writer.h
+++ b/src/main/cpp/log_writer.h
@@ -55,13 +55,13 @@ public:
 
     explicit LogWriter(ostream &output, GetFrameInformation frameLookup, jvmtiEnv *jvmti);
 
-    virtual void record(const timespec &ts, const JVMPI_CallTrace &trace, ThreadBucket *info = nullptr);
+    virtual void record(const timespec &ts, const JVMPI_CallTrace &trace, ThreadBucketPtr info = ThreadBucketPtr(nullptr));
 
-    void record(const JVMPI_CallTrace &trace, ThreadBucket *info = nullptr);
+    void record(const JVMPI_CallTrace &trace, ThreadBucketPtr info = ThreadBucketPtr(nullptr));
 
-    void recordTraceStart(const jint numFrames, map::HashType envHash, ThreadBucket *info);
+    void recordTraceStart(const jint numFrames, map::HashType envHash, ThreadBucketPtr info);
 
-    void recordTraceStart(const jint numFrames, map::HashType envHash, const timespec &ts, ThreadBucket *info);
+    void recordTraceStart(const jint numFrames, map::HashType envHash, const timespec &ts, ThreadBucketPtr info);
 
     // method are unique pointers, use a long to standardise
     // between 32 and 64 bits
@@ -83,7 +83,7 @@ private:
     ostream& output_;
     GetFrameInformation frameInfoFoo; 
 
-    jvmtiEnv *jvmti_;
+    jvmtiEnv *const jvmti_;
 
     unordered_set<method_id> knownMethods;
 
@@ -96,7 +96,7 @@ private:
 
     void inspectMethod(const method_id methodId, const JVMPI_CallFrame &frame);
 
-    void inspectThread(map::HashType &threadId, ThreadBucket *info);
+    void inspectThread(map::HashType &threadId, ThreadBucketPtr info);
 
     jint getLineNo(jint bci, jmethodID methodId);
 

--- a/src/main/cpp/processor.cpp
+++ b/src/main/cpp/processor.cpp
@@ -103,7 +103,7 @@ bool Processor::isRunning() const {
     return isRunning_.load(std::memory_order_relaxed);
 }
 
-void Processor::handle(JNIEnv *jniEnv, const timespec& ts, ThreadBucket *threadInfo, void *context) {
+void Processor::handle(JNIEnv *jniEnv, const timespec& ts, ThreadBucketPtr threadInfo, void *context) {
     // sample data structure
     STATIC_ARRAY(frames, JVMPI_CallFrame, config.maxFramesToCapture, MAX_FRAMES_TO_CAPTURE);
 
@@ -119,5 +119,5 @@ void Processor::handle(JNIEnv *jniEnv, const timespec& ts, ThreadBucket *threadI
     }
 
     // log all samples, failures included, let the post processing sift through the data
-    buffer.push(ts, trace, threadInfo);
+    buffer.push(ts, trace, std::move(threadInfo));
 }

--- a/src/main/cpp/processor.h
+++ b/src/main/cpp/processor.h
@@ -36,7 +36,7 @@ public:
 
     bool isRunning() const;
 
-    void handle(JNIEnv *jni_env, const timespec& ts, ThreadBucket *threadInfo, void *context);
+    void handle(JNIEnv *jni_env, const timespec& ts, ThreadBucketPtr threadInfo, void *context);
 
 private:
     jvmtiEnv *const jvmti_;

--- a/src/main/cpp/profiler.cpp
+++ b/src/main/cpp/profiler.cpp
@@ -23,7 +23,7 @@ void Profiler::handle(int signum, siginfo_t *info, void *context) {
     if (jvm_) {
         JNIEnv *jniEnv = getJNIEnv(jvm_);
         TimeUtils::current_utc_time(&spec); // sample current time
-        processor->handle(jniEnv, spec, jniEnv ? tMap_.get(jniEnv) : nullptr, context);
+        processor->handle(jniEnv, spec, jniEnv ? tMap_.get(jniEnv) : ThreadBucketPtr(nullptr), context);
     }
 }
 

--- a/src/main/cpp/thread_map.cpp
+++ b/src/main/cpp/thread_map.cpp
@@ -13,7 +13,7 @@ int gettid() {
 #if defined(__linux__)
   ret = syscall(SYS_gettid);
 #elif defined(__APPLE__)
-  //ret = pthread_getthreadid_np();
+  // ret = pthread_getthreadid_np();
   ret = mach_thread_self();
   mach_port_deallocate(mach_task_self(), ret);
 #elif defined(__NetBSD__)

--- a/src/main/cpp/thread_map.h
+++ b/src/main/cpp/thread_map.h
@@ -68,7 +68,9 @@ struct ThreadBucket {
 	~ThreadBucket() {}
 };
 
-// ThreadBucket* wrapper that does atomic reference counting and only supports move semantic
+// ThreadBucket* wrapper that does atomic reference counting and only supports move semantic.
+// Here weak means that ref counter is not incremented when wrapper is created, but it will 
+// be decremented once object is destroyed.
 class ThreadBucketPtr {
 public:
 	explicit ThreadBucketPtr(ThreadBucket *b, bool weak = true) : bucket(b) {

--- a/src/main/cpp/thread_map.h
+++ b/src/main/cpp/thread_map.h
@@ -1,163 +1,155 @@
 #ifndef THREAD_MAP_H
 #define THREAD_MAP_H
 
-#include <jvmti.h>
-#include <jni.h>
-#include <string.h>
 #include "concurrent_map.h"
-
+#include <jni.h>
+#include <jvmti.h>
+#include <string.h>
 
 int gettid();
 
-template <typename PType>
-struct PointerHasher {
-	/* Numerical Recipes, 3rd Edition */
-	static int64_t hash(void *p) {
-		int64_t v = (int64_t)p / sizeof(PType);
-		v = v * 3935559000370003845 + 2691343689449507681;
+template <typename PType> struct PointerHasher {
+  /* Numerical Recipes, 3rd Edition */
+  static int64_t hash(void *p) {
+    int64_t v = (int64_t)p / sizeof(PType);
+    v = v * 3935559000370003845 + 2691343689449507681;
 
-  		v ^= v >> 21;
-  		v ^= v << 37;
-  		v ^= v >>  4;
+    v ^= v >> 21;
+    v ^= v << 37;
+    v ^= v >> 4;
 
-  		v *= 4768777513237032717;
+    v *= 4768777513237032717;
 
-  		v ^= v << 20;
-  		v ^= v >> 41;
-  		v ^= v <<  5;
+    v ^= v << 20;
+    v ^= v >> 41;
+    v ^= v << 5;
 
-  		return v;
-	}
+    return v;
+  }
 };
 
 const int kInitialMapSize = 256;
 
 class GCHelper {
 public:
-	static map::GC::EpochType attach() {
-		return map::DefaultGC.attachThread();
-	}
+  static map::GC::EpochType attach() { return map::DefaultGC.attachThread(); }
 
-	static void detach(map::GC::EpochType &localEpoch) {
-		if (localEpoch != map::GC::kEpochInitial)
-			map::DefaultGC.detachThread(localEpoch);
-	}
+  static void detach(map::GC::EpochType &localEpoch) {
+    if (localEpoch != map::GC::kEpochInitial)
+      map::DefaultGC.detachThread(localEpoch);
+  }
 
-	static void safepoint(map::GC::EpochType &localEpoch) {
-		map::DefaultGC.safepoint(localEpoch);
-	}
+  static void safepoint(map::GC::EpochType &localEpoch) {
+    map::DefaultGC.safepoint(localEpoch);
+  }
 
-	static void signalSafepoint(map::GC::EpochType &localEpoch) {
-		map::DefaultGC.ss_safepoint(localEpoch);
-	}
+  static void signalSafepoint(map::GC::EpochType &localEpoch) {
+    map::DefaultGC.ss_safepoint(localEpoch);
+  }
 };
 
 struct ThreadBucket {
-	const int tid;
-	std::string name;
-	std::atomic_int refs;
-	map::GC::EpochType localEpoch;
+  const int tid;
+  std::string name;
+  std::atomic_int refs;
+  map::GC::EpochType localEpoch;
 
-	explicit ThreadBucket(int id, const char *n) : tid(id), name(n), refs(1), localEpoch(GCHelper::attach()) {
-	}
+  explicit ThreadBucket(int id, const char *n)
+      : tid(id), name(n), refs(1), localEpoch(GCHelper::attach()) {}
 
-	int release() {
-		return refs.fetch_sub(1, std::memory_order_acquire);
-	}
+  int release() { return refs.fetch_sub(1, std::memory_order_acquire); }
 
-	~ThreadBucket() {}
+  ~ThreadBucket() {}
 };
 
-// ThreadBucket* wrapper that does atomic reference counting and only supports move semantic.
-// Here weak means that ref counter is not incremented when wrapper is created, but it will 
-// be decremented once object is destroyed.
+/* ThreadBucket* wrapper that does atomic reference counting and only supports
+   move semantic. Here weak means that ref counter is not incremented when
+   wrapper is created, but it will be decremented once object is destroyed.
+*/
 class ThreadBucketPtr {
 public:
-	explicit ThreadBucketPtr(ThreadBucket *b, bool weak = true) : bucket(b) {
-		if (bucket && !weak) {
-			int prev = bucket->refs.fetch_add(1, std::memory_order_relaxed);
-			assert(prev >= 0);
-			if (prev == 0) {
-				// return to released state
-				bucket->refs.fetch_sub(1, std::memory_order_relaxed);
-			}
-		}
-	}
+  explicit ThreadBucketPtr(ThreadBucket *b, bool weak = true) : bucket(b) {
+    if (bucket && !weak) {
+      int prev = bucket->refs.fetch_add(1, std::memory_order_relaxed);
+      assert(prev >= 0);
+      if (prev == 0) {
+        // return to released state
+        bucket->refs.fetch_sub(1, std::memory_order_relaxed);
+      }
+    }
+  }
 
-	ThreadBucketPtr(ThreadBucketPtr&& tb) : bucket(tb.bucket) {
-		tb.bucket = nullptr;
-	}
+  ThreadBucketPtr(ThreadBucketPtr &&tb) : bucket(tb.bucket) {
+    tb.bucket = nullptr;
+  }
 
-	ThreadBucketPtr(const ThreadBucketPtr& tb) = delete;
+  ThreadBucketPtr(const ThreadBucketPtr &tb) = delete;
 
-	ThreadBucketPtr& operator=(ThreadBucketPtr&& tb) {
-		if (bucket && bucket->release() == 1) {
-			delete bucket;
-		}
-		bucket = tb.bucket;
-		tb.bucket = nullptr;
-		return *this;
-	}
+  ThreadBucketPtr &operator=(ThreadBucketPtr &&tb) {
+    if (bucket && bucket->release() == 1) {
+      delete bucket;
+    }
+    bucket = tb.bucket;
+    tb.bucket = nullptr;
+    return *this;
+  }
 
-	ThreadBucketPtr& operator=(const ThreadBucketPtr& tb) = delete;
+  ThreadBucketPtr &operator=(const ThreadBucketPtr &tb) = delete;
 
-	ThreadBucket* operator->() {
-		return bucket;
-	}
+  ThreadBucket *operator->() { return bucket; }
 
-	bool defined() const {
-		return bucket != nullptr;
-	}
+  bool defined() const { return bucket != nullptr; }
 
-	void reset() {
-		if (bucket && bucket->release() == 1) {
-			delete bucket;
-		}
-		bucket = nullptr;
-	}
+  void reset() {
+    if (bucket && bucket->release() == 1) {
+      delete bucket;
+    }
+    bucket = nullptr;
+  }
 
-	~ThreadBucketPtr() {
-		if (bucket && bucket->release() == 1) {
-			delete bucket;
-		}
-	}
+  ~ThreadBucketPtr() {
+    if (bucket && bucket->release() == 1) {
+      delete bucket;
+    }
+  }
 
 private:
-	ThreadBucket *bucket;
+  ThreadBucket *bucket;
 };
 
-template <typename MapProvider>
-class ThreadMapBase {
+template <typename MapProvider> class ThreadMapBase {
 private:
-	MapProvider map;
+  MapProvider map;
 
 public:
-	explicit ThreadMapBase(int capacity = kInitialMapSize) : map(capacity) {}
+  explicit ThreadMapBase(int capacity = kInitialMapSize) : map(capacity) {}
 
-	void put(JNIEnv *jni_env, const char *name) {
-		put(jni_env, name, gettid());
-	}
+  void put(JNIEnv *jni_env, const char *name) { put(jni_env, name, gettid()); }
 
-	void put(JNIEnv *jni_env, const char *name, int tid) {
-		ThreadBucket *info = new ThreadBucket(tid, name);
-		ThreadBucketPtr oldRef((ThreadBucket*)map.put((map::KeyType)jni_env, (map::ValueType)info)); // weak ref to object
-		GCHelper::safepoint(info->localEpoch); // each thread inserts once
-	}
+  void put(JNIEnv *jni_env, const char *name, int tid) {
+    ThreadBucket *info = new ThreadBucket(tid, name);
+    ThreadBucketPtr oldRef((ThreadBucket *)map.put(
+        (map::KeyType)jni_env, (map::ValueType)info)); // weak ref to object
+    GCHelper::safepoint(info->localEpoch); // each thread inserts once
+  }
 
-	ThreadBucketPtr get(JNIEnv *jni_env) {
-		ThreadBucketPtr info((ThreadBucket*)map.get((map::KeyType)jni_env), false); // non-weak ref
-		if (info.defined())
-			GCHelper::signalSafepoint(info->localEpoch);
-		return info; // move
-	}
+  ThreadBucketPtr get(JNIEnv *jni_env) {
+    ThreadBucketPtr info((ThreadBucket *)map.get((map::KeyType)jni_env),
+                         false); // non-weak ref
+    if (info.defined())
+      GCHelper::signalSafepoint(info->localEpoch);
+    return info; // move
+  }
 
-	void remove(JNIEnv *jni_env) {
-		ThreadBucketPtr info((ThreadBucket*)map.remove((map::KeyType)jni_env)); // weak ref to object
-		if (info.defined())
-			GCHelper::detach(info->localEpoch);
-	}
+  void remove(JNIEnv *jni_env) {
+    ThreadBucketPtr info((ThreadBucket *)map.remove(
+        (map::KeyType)jni_env)); // weak ref to object
+    if (info.defined())
+      GCHelper::detach(info->localEpoch);
+  }
 };
 
-typedef ThreadMapBase<map::ConcurrentMapProvider<PointerHasher<JNIEnv>, true> > ThreadMap;
+typedef ThreadMapBase<map::ConcurrentMapProvider<PointerHasher<JNIEnv>, true>>
+    ThreadMap;
 
 #endif

--- a/src/test/cpp/fixtures.h
+++ b/src/test/cpp/fixtures.h
@@ -8,14 +8,14 @@ class ItemHolder : public QueueListener {
 public:
   explicit ItemHolder() {}
 
-  void record(const JVMPI_CallTrace &trace, ThreadBucket *info) {
+  void record(const JVMPI_CallTrace &trace, ThreadBucketPtr info) {
     timespec spec;
     TimeUtils::current_utc_time(&spec);
 
-    record(spec, trace, info);
+    record(spec, trace, std::move(info));
   }
 
-  virtual void record(const timespec &ts, const JVMPI_CallTrace &trace, ThreadBucket *info) {
+  virtual void record(const timespec &ts, const JVMPI_CallTrace &trace, ThreadBucketPtr info) {
     CHECK_EQUAL(2, trace.num_frames);
     CHECK_EQUAL((JNIEnv *)envId, trace.env_id);
 

--- a/src/test/cpp/test_log_writer.cpp
+++ b/src/test/cpp/test_log_writer.cpp
@@ -37,7 +37,7 @@ TEST(RecordsStartOfStackTrace) {
   timespec tspec = {44, 55};
   ThreadBucketPtr tptr(threadInfo.get(), false);
 
-  logWriter.recordTraceStart(2, 3, tspec, std::move(tptr));
+  logWriter.recordTraceStart(2, 3, tspec, tptr);
   int cnt = 0; 
 
   CHECK_EQUAL(THREAD_META, buffer[cnt]);
@@ -63,7 +63,8 @@ TEST(SupportsHighThreadId) {
 
   // LONG_MAX
   long bigNumber = std::numeric_limits<long>::max();
-  logWriter.recordTraceStart(2, (map::HashType)bigNumber, tspec, ThreadBucketPtr(nullptr));
+  ThreadBucketPtr tBuck(nullptr);
+  logWriter.recordTraceStart(2, (map::HashType)bigNumber, tspec, tBuck);
 
   CHECK_EQUAL(THREAD_META, buffer[0]);
   CHECK_EQUAL(0, buffer[12]);

--- a/src/test/cpp/test_profiler_config.cpp
+++ b/src/test/cpp/test_profiler_config.cpp
@@ -7,7 +7,6 @@
 #include <iostream>
 #include "../../main/cpp/profiler.h"
 
-// Heavy tests that require a JVM instance can be disabled
 #ifndef TEST_SKIP_PROFILER
 
 static ThreadMap threadMap; // empty map

--- a/src/test/cpp/test_thread_map.cpp
+++ b/src/test/cpp/test_thread_map.cpp
@@ -4,103 +4,155 @@
 
 #include "../../main/cpp/thread_map.h"
 
+#include <memory>
 #include <thread>
 #include <vector>
-#include <memory>
 
-#define PTR std::unique_ptr<JNIEnv>((JNIEnv*)new int(0))
+#define ptr() std::unique_ptr<JNIEnv>((JNIEnv *)new int(0))
 
 TEST(ThreadMapPutGetDeleteTest) {
-    ThreadMap map;
-    auto p1 = PTR;
-    auto pid = 999;
-    auto name = "name321";
+  ThreadMap map;
+  auto p1 = ptr();
+  auto pid = 999;
+  auto name = "name321";
 
-    // map is empty
-    CHECK(!map.get(p1.get()).defined());
+  // map is empty
+  CHECK(!map.get(p1.get()).defined());
 
-    map.put(p1.get(), name, pid);
+  map.put(p1.get(), name, pid);
 
-    // try to create temporary references to the bucket
-    for (int i = 0; i < 4; i++) {
-        ThreadBucketPtr r1 = map.get(p1.get());
-        CHECK(r1.defined());
-        CHECK_EQUAL(r1->tid, pid);
-        CHECK_EQUAL(r1->name, name);
-    }
+  // try to create temporary references to the bucket
+  for (int i = 0; i < 4; i++) {
+    ThreadBucketPtr r1 = map.get(p1.get());
+    CHECK(r1.defined());
+    CHECK_EQUAL(pid, r1->tid);
+    CHECK_EQUAL(name, r1->name);
+  }
 
-    map.remove(p1.get());
+  map.remove(p1.get());
 
-    // map is empty again
-    CHECK(!map.get(p1.get()).defined());
+  // map is empty again
+  CHECK(!map.get(p1.get()).defined());
 }
 
 TEST(ThreadMapPutDeleteGetTest) {
-    ThreadMap map;
-    auto p1 = PTR;
-    auto pid = 999;
-    auto name = "name321";
+  ThreadMap map;
+  auto p1 = ptr();
+  auto pid = 999;
+  auto name = "name321";
 
-    // map is empty
+  // map is empty
+  CHECK(!map.get(p1.get()).defined());
+
+  map.put(p1.get(), name, pid);
+
+  {
+    ThreadBucketPtr r1 = map.get(p1.get()), r2 = map.get(p1.get()),
+                    r3 = map.get(p1.get());
+    map.remove(p1.get());
     CHECK(!map.get(p1.get()).defined());
 
-    map.put(p1.get(), name, pid);
+    CHECK(r1.defined());
+    CHECK(r2.defined());
+    CHECK(r3.defined());
 
-    {
-        ThreadBucketPtr r1 = map.get(p1.get()), r2 = map.get(p1.get()), r3 = map.get(p1.get());
-        map.remove(p1.get());
-        CHECK(!map.get(p1.get()).defined());
+    CHECK_EQUAL(pid, r2->tid);
+    CHECK_EQUAL(name, r2->name);
+  }
 
-        CHECK(r1.defined());
-        CHECK(r2.defined());
-        CHECK(r3.defined());
-
-        CHECK_EQUAL(r2->tid, pid);
-        CHECK_EQUAL(r2->name, name);
-    }
-
-    CHECK(!map.get(p1.get()).defined());
+  CHECK(!map.get(p1.get()).defined());
 }
 
 TEST(ThreadMapAssignResetTest) {
-    ThreadMap map;
-    auto p1 = PTR, p2 = PTR;
-    auto pid1 = 999, pid2 = 111;
-    auto name1 = "name321", name2 = "name123";
+  ThreadMap map;
+  auto p1 = ptr(), p2 = ptr();
+  auto pid1 = 999, pid2 = 111;
+  auto name1 = "name321", name2 = "name123";
 
-    // map is empty
+  // map is empty
+  CHECK(!map.get(p1.get()).defined());
+  CHECK(!map.get(p2.get()).defined());
+
+  map.put(p1.get(), name1, pid1);
+  map.put(p2.get(), name2, pid2);
+
+  {
+    ThreadBucketPtr r1 = map.get(p1.get());
+    CHECK(r1.defined());
+    CHECK_EQUAL(pid1, r1->tid);
+    CHECK_EQUAL(name1, r1->name);
+
+    map.remove(p1.get());
     CHECK(!map.get(p1.get()).defined());
+
+    r1 = map.get(p2.get());
+    CHECK(r1.defined());
+    CHECK_EQUAL(pid2, r1->tid);
+    CHECK_EQUAL(name2, r1->name);
+
+    map.remove(p2.get());
     CHECK(!map.get(p2.get()).defined());
 
-    map.put(p1.get(), name1, pid1);
-    map.put(p2.get(), name2, pid2);
+    r1.reset();
+    CHECK(!r1.defined());
 
-    {
-        ThreadBucketPtr r1 = map.get(p1.get());
-        CHECK(r1.defined());
-        CHECK_EQUAL(r1->tid, pid1);
-        CHECK_EQUAL(r1->name, name1);
+    r1.reset();
+  }
 
-        map.remove(p1.get());
-        CHECK(!map.get(p1.get()).defined());
+  // map is empty
+  CHECK(!map.get(p1.get()).defined());
+  CHECK(!map.get(p2.get()).defined());
+}
 
-        r1 = map.get(p2.get());
-        CHECK(r1.defined());
-        CHECK_EQUAL(r1->tid, pid2);
-        CHECK_EQUAL(r1->name, name2);
+void reader(ThreadMap &map, const int id, JNIEnv *const p,
+            std::atomic_int &read) {
+  ThreadBucketPtr ptr = map.get(p);
+  std::string name("thread-" + std::to_string(id));
 
-        map.remove(p2.get());
-        CHECK(!map.get(p2.get()).defined());
+  while (!ptr.defined()) {
+    sched_yield();
+    ptr = map.get(p);
+  }
 
-        r1.reset();
-        CHECK(!r1.defined());
+  read.fetch_add(1, std::memory_order_seq_cst);
+  do {
+    CHECK_EQUAL(name, ptr->name);
+    CHECK_EQUAL(id, ptr->tid);
+  } while ((ptr = map.get(p)).defined());
+}
 
-        r1.reset();
-    }
+TEST(ThreadMapConcurrentTest) {
+  const int sz = 4;
+  ThreadMap map;
 
-    // map is empty
-    CHECK(!map.get(p1.get()).defined());
-    CHECK(!map.get(p2.get()).defined());
+  std::atomic_int read(0);
+  std::vector<std::unique_ptr<JNIEnv>> ps(sz);
+  std::vector<std::thread> tvec(sz);
+
+  for (auto it = ps.begin(); it != ps.end(); ++it) {
+    *it = ptr();
+    int id = it - ps.begin();
+    tvec[id] =
+        std::thread(reader, std::ref(map), id, it->get(), std::ref(read));
+  }
+
+  for (auto it = ps.begin(); it != ps.end(); ++it) {
+    int id = it - ps.begin();
+    std::string name("thread-" + std::to_string(id));
+    map.put(it->get(), name.c_str(), id);
+  }
+
+  while (read.load(std::memory_order_acquire) != sz)
+    sched_yield();
+
+  for (auto it = ps.begin(); it != ps.end(); ++it) {
+    map.remove(it->get());
+  }
+
+  for (auto it = tvec.begin(); it != tvec.end(); ++it) {
+    it->join();
+    CHECK(!map.get(ps[it - tvec.begin()].get()).defined());
+  }
 }
 
 #endif // DISABLE_CPP11

--- a/src/test/cpp/test_thread_map.cpp
+++ b/src/test/cpp/test_thread_map.cpp
@@ -1,0 +1,106 @@
+#include "test.h"
+
+#ifndef DISABLE_CPP11
+
+#include "../../main/cpp/thread_map.h"
+
+#include <thread>
+#include <vector>
+#include <memory>
+
+#define PTR std::unique_ptr<JNIEnv>((JNIEnv*)new int(0))
+
+TEST(ThreadMapPutGetDeleteTest) {
+    ThreadMap map;
+    auto p1 = PTR;
+    auto pid = 999;
+    auto name = "name321";
+
+    // map is empty
+    CHECK(!map.get(p1.get()).defined());
+
+    map.put(p1.get(), name, pid);
+
+    // try to create temporary references to the bucket
+    for (int i = 0; i < 4; i++) {
+        ThreadBucketPtr r1 = map.get(p1.get());
+        CHECK(r1.defined());
+        CHECK_EQUAL(r1->tid, pid);
+        CHECK_EQUAL(r1->name, name);
+    }
+
+    map.remove(p1.get());
+
+    // map is empty again
+    CHECK(!map.get(p1.get()).defined());
+}
+
+TEST(ThreadMapPutDeleteGetTest) {
+    ThreadMap map;
+    auto p1 = PTR;
+    auto pid = 999;
+    auto name = "name321";
+
+    // map is empty
+    CHECK(!map.get(p1.get()).defined());
+
+    map.put(p1.get(), name, pid);
+
+    {
+        ThreadBucketPtr r1 = map.get(p1.get()), r2 = map.get(p1.get()), r3 = map.get(p1.get());
+        map.remove(p1.get());
+        CHECK(!map.get(p1.get()).defined());
+
+        CHECK(r1.defined());
+        CHECK(r2.defined());
+        CHECK(r3.defined());
+
+        CHECK_EQUAL(r2->tid, pid);
+        CHECK_EQUAL(r2->name, name);
+    }
+
+    CHECK(!map.get(p1.get()).defined());
+}
+
+TEST(ThreadMapAssignResetTest) {
+    ThreadMap map;
+    auto p1 = PTR, p2 = PTR;
+    auto pid1 = 999, pid2 = 111;
+    auto name1 = "name321", name2 = "name123";
+
+    // map is empty
+    CHECK(!map.get(p1.get()).defined());
+    CHECK(!map.get(p2.get()).defined());
+
+    map.put(p1.get(), name1, pid1);
+    map.put(p2.get(), name2, pid2);
+
+    {
+        ThreadBucketPtr r1 = map.get(p1.get());
+        CHECK(r1.defined());
+        CHECK_EQUAL(r1->tid, pid1);
+        CHECK_EQUAL(r1->name, name1);
+
+        map.remove(p1.get());
+        CHECK(!map.get(p1.get()).defined());
+
+        r1 = map.get(p2.get());
+        CHECK(r1.defined());
+        CHECK_EQUAL(r1->tid, pid2);
+        CHECK_EQUAL(r1->name, name2);
+
+        map.remove(p2.get());
+        CHECK(!map.get(p2.get()).defined());
+
+        r1.reset();
+        CHECK(!r1.defined());
+
+        r1.reset();
+    }
+
+    // map is empty
+    CHECK(!map.get(p1.get()).defined());
+    CHECK(!map.get(p2.get()).defined());
+}
+
+#endif // DISABLE_CPP11


### PR DESCRIPTION
Hi,

This PR changes `ThreadMap::get` public API (as well as some internal parts of the class), so instead of returning a pointer to internally allocated `ThreadBucket` and managing it's lifecycle directly by calling `release()` method in `LogWriter::record`, the method will return a `ThreadBucketPtr`  wrapper of it. Wrapper will do automatic and atomic reference counting upon construction/destruction and can only be moved. It is moved from signal handler callback to `CircularQueue` and then to `LogWriter`. There's no need to explicitly call any methods (except for std::move in certain cases), once Bucket goes out of scope pointer will be processed correctly. I added a couple of unit tests for thread map as well.

I also did 2 minor changes: 
1. Removed `#ifdef GETENV_NEW_THREAD_ASYNC_UNSAFE` that protects `controller->start()`. 
It allows to use controller on Mac when both port and host are defined. If controller doesn't work properly for someone, it can be disabled easily at runtime, there's no need to remove it completely.
2. Added .clang-format file, so uniform cpp code style can be used reused. I only applied it to `thread_map.h`, `thread_map.cpp` and corresponding test, since I'm not sure everyone will like it.