### PR TITLE
Fix unresponsiveness of agent when sampling duration is large

### DIFF
--- a/src/main/cpp/processor.cpp
+++ b/src/main/cpp/processor.cpp
@@ -22,17 +22,20 @@ void sleep_for_millis(uint period) {
 }
 
 void Processor::sleep(uint period) {
+    // check 'isRunning_' every STATUS_CHECK_PERIOD ms in case period is too large.
+    // Allows agent to respond to stop/VM quit within STATUS_CHECK_PERIOD ms at the cost of fudging
+    // accuracy of sleep a bit
     const int loop = period / STATUS_CHECK_PERIOD;
     const int remainder = period % STATUS_CHECK_PERIOD;
 
     int count = 0;
     while (count < loop && isRunning_.load(std::memory_order_relaxed)) {
-      count ++;
-      sleep_for_millis(STATUS_CHECK_PERIOD);
+       count ++;
+       sleep_for_millis(STATUS_CHECK_PERIOD);
     }
 
     if (remainder > 0 && isRunning_.load(std::memory_order_relaxed)) {
-      sleep_for_millis(remainder);
+       sleep_for_millis(remainder);
     }
 }
 

--- a/src/main/cpp/processor.h
+++ b/src/main/cpp/processor.h
@@ -54,7 +54,7 @@ private:
 
     void startCallback(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *arg);
 
-    void sleep_for_millis(uint period);
+    void sleep(uint period);
 
     DISALLOW_COPY_AND_ASSIGN(Processor);
 };

--- a/src/main/cpp/processor.h
+++ b/src/main/cpp/processor.h
@@ -54,6 +54,8 @@ private:
 
     void startCallback(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *arg);
 
+    void sleep_for_millis(uint period);
+
     DISALLOW_COPY_AND_ASSIGN(Processor);
 };
 


### PR DESCRIPTION

When sampling interval is set to a large value (10's of seconds), VM does not respond to exit and/or Agent.stop() blocks until the sampling duration has elapsed due to Processor sleep'ing.