### PR TITLE
Correct timeunit conversion in timer's registration

### DIFF
--- a/src/main/cpp/signal_handler.cpp
+++ b/src/main/cpp/signal_handler.cpp
@@ -31,8 +31,8 @@ bool SignalHandler::updateSigprofInterval(const int timingInterval) {
         return true;
     static struct itimerval timer;
     // timingInterval is in milliseconds, not seconds.
-    timer.it_interval.tv_sec = (timingInterval / 1000000) / 1000;
-    timer.it_interval.tv_usec = timingInterval % 1000;
+    timer.it_interval.tv_sec = timingInterval / 1000;
+    timer.it_interval.tv_usec = (timingInterval * 1000) % 1000000;
     timer.it_value = timer.it_interval;
     if (setitimer(ITIMER_PROF, &timer, 0) == -1) {
         logError("Scheduling profiler interval failed with error %d\n", errno);


### PR DESCRIPTION
Proposal for this fix arose from issue #177 and my own personal research. Timer interval registration still seems to be off even after the 302e59d289f36f6ecd170afed5c7b87bd1da6dd7 commit.  

Given that the `timingInterval` is provided in millisecond units, the old version registers the timer with wrong values. Suppose that you set the timing interval with the `interval` flag to `10`. The old version would set the timer's second interval (`it_interval.tv_sec`) to `0` and microsecond value (`it_interval.tv_usec`) to `10`, resulting in a significantly smaller interval as intended (10 microseconds). 

Since the timer registration sets wrong values, it might introduce unexpected results. As issue #177 described, having such a low interval for the itimer configured by ITIMER_REAL limits the actual interval to 1 jiffy which is defined by kernel's clock rate.
