### PR TITLE
Change jackson version to match spark dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,8 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.5</version>
+            <!-- <version>2.8.5</version> -->
+            <version>2.6.7</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
honest profiler does not, currently, use any of the additional functionality exposed by the higher jackson version.
Unfortuantely, the profiler jackson dependency causes apache spark applications to fail due to version incompatibilities in jackson.

We have been successfully running it in production with the version lowered.