### PR TITLE
Make unittest++ optional for cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,11 @@ if (DEFINED ENV{UNITTEST_INCLUDE_DIRS})
     file(GLOB_RECURSE UNIT_TEST_H $ENV{UNITTEST_INCLUDE_DIRS}/*UnitTest++.h)
 else()
     if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-        find_package(UnitTest++ REQUIRED NO_MODULE)
-        include_directories(${UTPP_INCLUDE_DIRS})
+        pkg_check_modules (UnitTest++ QUIET unittest++)
+        if (${unittest++_FOUND})
+            find_package(UnitTest++ REQUIRED NO_MODULE)
+            include_directories(${UTPP_INCLUDE_DIRS})
+        endif()
     else()
         #Debian/Ubuntu have their own unittest++ pkg-config package
         pkg_check_modules (unittest++ QUIET unittest++)
@@ -48,11 +51,11 @@ else()
         endif()
         include_directories(${unittest++_INCLUDE_DIRS})
     endif()
-    file(GLOB_RECURSE UNIT_TEST_H ${unittest++_INCLUDE_DIRS}/*UnitTest++.h)
 endif()
 
-get_filename_component(UNIT_TEST_INCL ${UNIT_TEST_H} DIRECTORY)
-include_directories(${UNIT_TEST_INCL})
+if (${unittest++_FOUND})
+    file(GLOB_RECURSE UNIT_TEST_H ${unittest++_INCLUDE_DIRS}/*UnitTest++.h)
+endif()
 
 # include of gcc 4.8 headers specifically to work around
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=729933
@@ -84,17 +87,21 @@ set(SOURCE_FILES
     ${SRC}/concurrent_map.h
     ${SRC}/concurrent_map.cpp)
 
-set(TEST_FILES
-    ${SRC_TEST}/fixtures.h
-    ${SRC_TEST}/test_circular_queue.cpp
-    ${SRC_TEST}/test.cpp
-    ${SRC_TEST}/test_log_writer.cpp
-    ${SRC_TEST}/test_agent.cpp
-    ${SRC_TEST}/test.h
-    ${SRC_TEST}/test_profiler_config.cpp
-    ${SRC_TEST}/test_maps.cpp
-    ${SRC_TEST}/test_thread_map.cpp)
+if (${unittest++_FOUND})
+    get_filename_component(UNIT_TEST_INCL ${UNIT_TEST_H} DIRECTORY)
+    include_directories(${UNIT_TEST_INCL})
 
+    set(TEST_FILES
+        ${SRC_TEST}/fixtures.h
+        ${SRC_TEST}/test_circular_queue.cpp
+        ${SRC_TEST}/test.cpp
+        ${SRC_TEST}/test_log_writer.cpp
+        ${SRC_TEST}/test_agent.cpp
+        ${SRC_TEST}/test.h
+        ${SRC_TEST}/test_profiler_config.cpp
+        ${SRC_TEST}/test_maps.cpp
+        ${SRC_TEST}/test_thread_map.cpp)
+endif()
 
 ##########################################################
 # Compiler Options
@@ -152,18 +159,19 @@ else()
     target_link_libraries(${OUTPUT} ${JAVA_JVM_LIBRARY} dl rt)
 endif()
 
-add_executable(unitTests ${UNIT_TEST_H} ${TEST_FILES})
+if (${unittest++_FOUND})
+    add_executable(unitTests ${UNIT_TEST_H} ${TEST_FILES})
 
-if (DEFINED ENV{UNITTEST_LIBRARIES})
-    message("User has configured " $ENV{UNITTEST_LIBRARIES} " as the unit test libraries")
-    target_link_libraries(unitTests ${OUTPUT} $ENV{UNITTEST_LIBRARIES})
-else()
-    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-        target_link_libraries(unitTests ${OUTPUT} UnitTest++)
+    if (DEFINED ENV{UNITTEST_LIBRARIES})
+        message("User has configured " $ENV{UNITTEST_LIBRARIES} " as the unit test libraries")
+        target_link_libraries(unitTests ${OUTPUT} $ENV{UNITTEST_LIBRARIES})
     else()
-        target_link_libraries(unitTests ${OUTPUT} ${unittest++_LIBRARIES})
+        if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+            target_link_libraries(unitTests ${OUTPUT} UnitTest++)
+        else()
+            target_link_libraries(unitTests ${OUTPUT} ${unittest++_LIBRARIES})
+        endif()
     endif()
-endif()
 
-# make test
-add_test(unitTests ${BIN}/unitTests)
+    add_test(unitTests ${BIN}/unitTests)
+endif()


### PR DESCRIPTION
The unittest++ requirement is onerous for building on a restricted system that only has CMake and C++ available. This makes it optional.

Note: I was unable to test this on Linux or with user-provided UnitTest++ headers. Help wanted!