### PR TITLE
Some changes to start supporting Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,6 @@
             <version>2.15</version>
         </dependency>
         <dependency>
-            <groupId>com.sun</groupId>
-            <artifactId>tools</artifactId>
-            <version>8</version>
-            <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
-        <dependency>
             <groupId>org.webbitserver</groupId>
             <artifactId>webbit</artifactId>
             <version>0.4.15</version>
@@ -36,7 +29,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <!-- <version>2.8.5</version> -->
             <version>2.6.7</version>
         </dependency>
         <dependency>
@@ -65,13 +57,13 @@
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-core</artifactId>
-            <version>4.0.6-alpha</version>
+            <version>4.0.16-alpha</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-junit</artifactId>
-            <version>4.0.6-alpha</version>
+            <version>4.0.15-alpha</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -79,6 +71,21 @@
             <artifactId>openjfx-monocle</artifactId>
             <version>1.8.0_20</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>11.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>11.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
* Use OpenJFX 11
* Add annotation-api dependency
* Remove tools.jar dependency
* Use recent TestFX that accesses Robot properly

This last bullet is not quite working; even though
TestFX/TestFX#629 claims this has been fixed I continue to get
NoClassDefFoundError when trying to run tests.

This is a work in progress. The TestFX blocker is reported at TestFX/TestFX#691.

I'm hopeful that's the only blocker remaining for this to build and test successfully on Java 11.