### PR TITLE
Run all the tests in multiple forked VM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,7 @@
 			    <version>2.19.1</version>
 			    <configuration>
 			    	<argLine>-Duser.country=US -Duser.language=en -Dheadless=true</argLine>
+			    	<forkCount>1.5C</forkCount>
 			    </configuration>
 			</plugin>
         </plugins>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
